### PR TITLE
Do not persist the login

### DIFF
--- a/apis/index.js
+++ b/apis/index.js
@@ -14,7 +14,8 @@ export function initialize() {
 }
 
 export function signIn(token) {
-  return firebase.auth().signInWithCustomToken(token);
+  return firebase.auth().setPersistence(firebase.auth.Auth.Persistence.NONE)
+    .then(() => firebase.auth().signInWithCustomToken(token));
 }
 
 export function signOut() {


### PR DESCRIPTION
Do not persist the login. This should prevent the firebase restore logic from conflicting with our auth logic.

My Testing: YOLO