### PR TITLE
Putting back in the region tracking to keep the map zoomed in

### DIFF
--- a/screens/overviewMap.js
+++ b/screens/overviewMap.js
@@ -221,8 +221,11 @@ class OverviewMap extends PureComponent {
           showsTraffic={false}
           showsIndoors={false}
           showsBuildings={false}
+          region={this.state}
+          initialRegion={this.state}
           provider="google"
-          initialRegion={this.initialRegion}
+          minZoomLevel={10}
+          maxZoomLevel={20}
           onMapReady={this.onMapReady}
           onRegionChange={() => this.setState({ centered: false })}
           onRegionChangeComplete={this.onRegionChangeComplete}


### PR DESCRIPTION
![Begin like this](https://user-images.githubusercontent.com/103917/38594047-8d5e9784-3d12-11e8-8d7e-b18e62dccadd.png)

When loading app start by being zoomed in. I reconnected this to the region property. We can work on making that smoother later.

My Testing:

* Moving around
* Adding a pin (nothing borked)