### PR TITLE
Location creation time fix

### DIFF
--- a/apis/database.js
+++ b/apis/database.js
@@ -1,9 +1,10 @@
 import { SQLite } from 'expo';
 import Sentry from 'sentry-expo';
+import moment from 'moment';
 import { pushRef } from './index';
 import { convertArrayToLocations, convertToLocation, createLocationObject, saveCoordinates } from '../utils/database';
 
-export function openDatabase(databaseName = 'locations.db') {
+export function openDatabase(databaseName = 'locations.1.db') {
   return SQLite.openDatabase(databaseName);
 }
 
@@ -75,7 +76,7 @@ export async function addLocalLocation(locationData) {
   // Store the longitude and latitude in secure storage with same locationKey from DB
   saveCoordinates(key, latitude, longitude);
 
-  const createdAt = locationObject.created.toString();
+  const createdAt = moment.utc(locationObject.created).toISOString();
   await executeTransaction(
     'insert into locations (key, coordinateKey, createdAt, resources, status, uploaded) values (?, ?, ?, ?, ?, ?)',
     [key, key, createdAt, resourcesString, status, 0],

--- a/utils/database.js
+++ b/utils/database.js
@@ -31,7 +31,7 @@ export async function convertToLocation(location) {
   const {
     key, resources, status, uploaded,
   } = location;
-  const created = parseInt(location.createdAt, 10);
+  const created = moment(location.createdAt).valueOf();
   const { longitude, latitude } = await getCoordinates(key);
   return {
     key,


### PR DESCRIPTION
The time of a location creation was not being stored properly in the database. I was storing it as an integer but according to SQLite docs, integers are 8-bit signed which is not large enough so it was truncating our values. It would always store a time that is like 48 years ago.

The downside with this fix is that we have to convert the time between strings and integers a lot.

Also, I think there might be an issue with this not fixing existing peoples apps as the database needs to be recreated with the time being stored as text instead of an integer. Any Idea on how to solve this issue? Or is it not worth worrying about since not a lot of people are using the app and those that are can just uninstall and reinstall.