### PR TITLE
Saving reload auth

### DIFF
--- a/App.js
+++ b/App.js
@@ -14,6 +14,7 @@ import { initialize } from './apis';
 import { restore } from './actions/authentication';
 import { setup } from './actions/connectivity';
 import I18n from './assets/i18n/i18n';
+import * as overviewActions from './actions/overview';
 import * as positionActions from './actions/position';
 import { restoreLocalLocations } from './actions/locations';
 import * as settingsActions from './actions/settings';
@@ -44,8 +45,8 @@ class App extends Component {
     Promise.all([
       ...this.loadFontsAsync(),
       createDatabases(),
-      store.dispatch(positionActions.initialize()),
       I18n.initAsync(),
+      store.dispatch(positionActions.initialize()),
       store.dispatch(settingsActions.load({
         enableInvitations: Constants.manifest.extra.enableInvitations,
       })),
@@ -53,7 +54,7 @@ class App extends Component {
       I18n.setDateLocale();
       this.setState({ isReady: true });
       return Promise.all([
-        store.dispatch(restore()),
+        store.dispatch(restore()).then(restored => restored && store.dispatch(overviewActions.initialize())),
         store.dispatch(restoreLocalLocations()),
       ]);
     });

--- a/actions/authentication.js
+++ b/actions/authentication.js
@@ -62,7 +62,7 @@ export function restore() {
   return async (dispatch, getState) => {
     const { settings: { enableInvitations } } = getState();
     if (!enableInvitations) {
-      return;
+      return false;
     }
 
     let values;
@@ -73,11 +73,12 @@ export function restore() {
     }
 
     if (!values || !values.refreshToken) {
-      return;
+      return false;
     }
 
     dispatch(accepted(values));
     await dispatch(authenticate(values.refreshToken));
+    return true;
   };
 }
 


### PR DESCRIPTION
Ensuring your auth tokens is reloaded when the app is restarted and that it starts loading points again immediately. I would include images here, but it would give away my secrets.

My Testing:

* Reloading the application with a token, it logs back in immediately and starts loading pins
* Logging out and then reloading, no pins are pulled in. No previously fetched pins are included.