### PR TITLE
Removing some dead actions/calls, we can add them back later as needed

### DIFF
--- a/actions/locations.js
+++ b/actions/locations.js
@@ -7,14 +7,14 @@ import * as database from '../apis/database';
 import { LOCATION_UPLOADED } from '../utils/database';
 
 export const RECIEVE_LOCATION = 'RECIEVE_LOCATION';
-export function receiveLocation(location) {
+function receiveLocation(location) {
   return {
     type: RECIEVE_LOCATION,
     location,
   };
 }
 
-export function updateUploadStatus(location, isUploaded) {
+function updateUploadStatus(location, isUploaded) {
   return (dispatch) => {
     const newLocation = { ...location, uploaded: isUploaded };
     dispatch(receiveLocation(newLocation));

--- a/actions/locations.js
+++ b/actions/locations.js
@@ -85,35 +85,6 @@ export function fetchAllLocationData(locationKey) {
   };
 }
 
-export function updateLocation(options) {
-  return async (dispatch, getState) => {
-    const { authentication: { regionKey }, locations, connected } = getState();
-    const original = { ...locations[options.key] };
-
-    const isUpdated = await database.updateLocalLocation({ ...original, ...options });
-
-    if (!isUpdated) {
-      throw new Error('Unable to update location! Please try again.');
-    }
-
-    if (connected) {
-      return apis.updateLocation(regionKey, { ...original, ...options })
-        .then(({ updated, saved }) => {
-          dispatch(receiveLocation({ ...original, ...updated }));
-
-          saved
-            .then(() => updateUploadStatus({ ...original, ...updated }, true))
-            .catch(() => {
-              dispatch(receiveLocation(original));
-              dispatch(fetchLocation(original.key));
-            });
-        });
-    }
-
-    return true;
-  };
-}
-
 export function createLocation(options) {
   const {
     latitude, longitude, resources, status,

--- a/apis/index.js
+++ b/apis/index.js
@@ -79,24 +79,6 @@ export function fetchLocation(locationKey) {
     .then(location => location.val());
 }
 
-export function updateLocation(regionKey, options) {
-  initialize();
-
-  const { key, status } = options;
-  const updated = { status };
-
-  const updateKeys = {};
-  Object.entries(updated).forEach(([item, value]) => {
-    // Don't update values if it wasn't provided:
-    if (value === undefined) { return; }
-    updateKeys[`${key}/${item}`] = value;
-  });
-
-  const saved = firebase.database().ref('locations').update(updateKeys);
-
-  return Promise.resolve({ updated, saved });
-}
-
 export async function createLocation(regionKey, options, key) {
   initialize();
 


### PR DESCRIPTION
Removing the `updateLocation` method. We were not using it and I would rather implement it again later.

My Testing: YOLO