### PR TITLE
Include regionKey in the data pushed to firebase

### DIFF
--- a/apis/index.js
+++ b/apis/index.js
@@ -108,6 +108,7 @@ export async function createLocation(regionKey, options, key) {
   }
 
   const created = createLocationObject(pushed.key, options);
+  created.regionKey = regionKey;
 
   const saved = pushed.set(created);
   const geoPromises = saveGeoData(created, pushed.key, regionKey);


### PR DESCRIPTION
It looks like we were not pushing regionKey along with the locations we shared. I need this so we can further lock down the data we are pushing.

My Testing:

* Pushing a location matching the user (pending)