### PR TITLE
Remove downloaded pins on logout

### DIFF
--- a/actions/authentication.js
+++ b/actions/authentication.js
@@ -2,6 +2,7 @@ import { Constants, SecureStore } from 'expo';
 import Sentry from 'sentry-expo';
 import { clear as clearRegions, request as requestRegion } from './regions';
 import { signIn, signOut } from '../apis';
+import { clearLocations, restoreLocalLocations } from './locations';
 import refetch from '../utils/refetch';
 
 const { serviceUrl } = Constants.manifest.extra;
@@ -28,6 +29,8 @@ export function logout() {
     await clear();
     dispatch(accepted({}));
     dispatch(clearRegions());
+    dispatch(clearLocations());
+    dispatch(restoreLocalLocations());
     await signOut();
   };
 }

--- a/actions/locations.js
+++ b/actions/locations.js
@@ -14,6 +14,13 @@ function receiveLocation(location) {
   };
 }
 
+export const CLEAR_LOCATIONS = 'CLEAR_LOCATIONS';
+export function clearLocations() {
+  return {
+    type: CLEAR_LOCATIONS,
+  };
+}
+
 function updateUploadStatus(location, isUploaded) {
   return (dispatch) => {
     const newLocation = { ...location, uploaded: isUploaded };

--- a/reducers/locations.js
+++ b/reducers/locations.js
@@ -1,11 +1,17 @@
-import { RECIEVE_LOCATION } from '../actions/locations';
+import { RECIEVE_LOCATION, CLEAR_LOCATIONS } from '../actions/locations';
 
-export default function reducer(state = {}, action) {
+const initial = {};
+
+export default function reducer(state = initial, action) {
   if (action.type === RECIEVE_LOCATION) {
     return {
       ...state,
       [action.location.key]: action.location,
     };
+  }
+
+  if (action.type === CLEAR_LOCATIONS) {
+    return initial;
   }
 
   return state;


### PR DESCRIPTION
This should make it so that when the user logs out or their token expires that the pins are cleared that they previously had downloaded. (But will keep local locations)

Separate PR still probably needs to be made to ensure that when tokens expire the user is logged out.