### PR TITLE
Local only mode

### DIFF
--- a/actions/connectivity.js
+++ b/actions/connectivity.js
@@ -1,10 +1,20 @@
 import { NetInfo } from 'react-native';
+import { SecureStore } from 'expo';
+import { clearLocations, restoreLocalLocations } from './locations';
 
 export const SET_CONNECTED = 'SET_CONNECTED';
 export function setConnected(connected) {
   return {
     type: SET_CONNECTED,
     connected,
+  };
+}
+
+export const SET_MODE = 'SET_MODE';
+export function setMode(isOfflineOnly) {
+  return {
+    type: SET_MODE,
+    isOfflineOnly,
   };
 }
 
@@ -20,13 +30,33 @@ function update(info) {
   };
 }
 
+export const OFFLINE_ONLY_KEY = 'isOfflineOnly';
+export function updateMode(isOfflineOnly) {
+  return async (dispatch) => {
+    await SecureStore.setItemAsync(OFFLINE_ONLY_KEY, isOfflineOnly.toString());
+    dispatch(setMode(isOfflineOnly));
+
+    if (isOfflineOnly) {
+      dispatch(clearLocations());
+      dispatch(restoreLocalLocations());
+    }
+  };
+}
+
 export function setup() {
-  return (dispatch) => {
+  return async (dispatch) => {
     NetInfo.addEventListener(
       'connectionChange',
       info => dispatch(update(info)),
     );
 
     NetInfo.getConnectionInfo().then(info => dispatch(update(info)));
+
+    let isOfflineOnly = await SecureStore.getItemAsync(OFFLINE_ONLY_KEY);
+    if (isOfflineOnly === null) {
+      await SecureStore.setItemAsync(OFFLINE_ONLY_KEY, 'false');
+      isOfflineOnly = 'false';
+    }
+    dispatch(setMode(isOfflineOnly === 'true'));
   };
 }

--- a/actions/locations.js
+++ b/actions/locations.js
@@ -72,7 +72,7 @@ export function restoreLocalLocations() {
 
 export function fetchLocation(locationKey) {
   return async (dispatch, getState) => {
-    const { authentication: { regionKey }, connected } = getState();
+    const { authentication: { regionKey }, connectivity: { connected } } = getState();
     if (!connected || !regionKey) {
       return;
     }
@@ -100,7 +100,7 @@ export function createLocation(options) {
   } = options;
 
   return async (dispatch, getState) => {
-    const { authentication: { regionKey: hasRegion }, connected } = getState();
+    const { authentication: { regionKey: hasRegion }, connectivity: { connected } } = getState();
 
     const locationData = {
       latitude, longitude, resources, status,
@@ -132,7 +132,7 @@ export function createLocation(options) {
 
 export function pushLocalLocations() {
   return async (dispatch, getState) => {
-    const { authentication: { regionKey: hasRegion }, connected } = getState();
+    const { authentication: { regionKey: hasRegion }, connectivity: { connected } } = getState();
     if (!connected || !hasRegion) {
       return false;
     }

--- a/actions/overview.js
+++ b/actions/overview.js
@@ -25,9 +25,9 @@ function updateLocations() {
     if (query) {
       query.cancel();
     }
-    const { position } = getState();
+    const { position, connectivity: { isOfflineOnly } } = getState();
     const key = dispatch(getGeoKey());
-    if (!key) {
+    if (!key || isOfflineOnly) {
       return;
     }
 

--- a/actions/settings.js
+++ b/actions/settings.js
@@ -13,7 +13,7 @@ export function load(settings) {
 
 export function showPushDialog() {
   return (dispatch, getState) => {
-    const { connected } = getState();
+    const { connectivity: { connected } } = getState();
 
     if (!connected) {
       Alert.alert(

--- a/assets/i18n/locales/en.json
+++ b/assets/i18n/locales/en.json
@@ -40,6 +40,7 @@
   "settings/location_data": "Location Data",
   "settings/logout": "Logout",
   "settings/not_implemented": "Sorry this feature isn't available yet.",
+  "settings/offline_only": "Local Locations Only:",
   "settings/push_locations_clear": "DEV: Clear Push",
   "settings/push_locations_message": "Pushing location data will send all locally stored location data to the central database for others to access. Would you like to push your data?",
   "settings/push_locations": "Push Location Data",

--- a/components/Settings.js
+++ b/components/Settings.js
@@ -1,7 +1,7 @@
 /* globals __DEV__ */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Image, Picker, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Image, Picker, ScrollView, StyleSheet, Text, View, Switch } from 'react-native';
 import SettingsItem from '../components/SettingsItem';
 
 import colours from '../styles/colours';
@@ -36,7 +36,8 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-start',
     alignSelf: 'flex-start',
     paddingVertical: 10,
-    paddingHorizontal: 20,
+    paddingLeft: 20,
+    paddingRight: 10,
     width: '100%',
   },
   version_container: {
@@ -82,12 +83,14 @@ const Settings = (props) => {
     clearPushPermission,
     enableInvitations,
     exportData,
+    isOfflineOnly,
     showLocationData,
     logout,
     regionKey,
     sendFeedback,
     showPushDialog,
     updateLocale,
+    updateMode,
     version,
   } = props;
 
@@ -122,6 +125,10 @@ const Settings = (props) => {
         { __DEV__ && <SettingsItem term="settings/push_locations_clear" onPress={clearPushPermission} /> }
         <SettingsItem term="settings/export" onPress={exportData} />
         <SettingsItem term="settings/send_feedback" onPress={sendFeedback} />
+        <View style={SettingsItem.styles.container}>
+          <Text style={SettingsItem.styles.text}>{I18n.t('settings/offline_only')}</Text>
+          <Switch onValueChange={updateMode} value={isOfflineOnly} />
+        </View>
         { regionKey && <SettingsItem term="settings/logout" onPress={logout} /> }
       </View>
       <View style={styles.version_container}>
@@ -141,12 +148,14 @@ Settings.propTypes = {
   clearPushPermission: PropTypes.func.isRequired,
   enableInvitations: PropTypes.bool.isRequired,
   exportData: PropTypes.func.isRequired,
+  isOfflineOnly: PropTypes.bool.isRequired,
   showLocationData: PropTypes.func.isRequired,
   logout: PropTypes.func.isRequired,
   regionKey: PropTypes.string,
   sendFeedback: PropTypes.func.isRequired,
   showPushDialog: PropTypes.func.isRequired,
   updateLocale: PropTypes.func.isRequired,
+  updateMode: PropTypes.func.isRequired,
   version: PropTypes.string.isRequired,
 };
 

--- a/containers/Settings.js
+++ b/containers/Settings.js
@@ -10,6 +10,7 @@ import { showPushDialog } from '../actions/settings';
 import I18n, { updateLocale } from '../actions/i18n';
 import { clearPushPermission } from '../actions/permissions';
 import { UploadStatus } from '../actions/uploads';
+import { updateMode } from '../actions/connectivity';
 import emails from '../assets/constants/emails';
 import toCsv from '../utils/csv';
 
@@ -27,6 +28,7 @@ const mapStateToProps = state => ({
   locale: state.i18n.locale, // triggers rerender on local change
   version: Constants.manifest.version,
   canUpload: hasPending(state),
+  isOfflineOnly: state.connectivity.isOfflineOnly,
 });
 
 const exportData = async () => {
@@ -93,6 +95,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
     ownProps.navigation.setParams({ locale });
     dispatch(updateLocale(locale));
   },
+  updateMode: value => dispatch(updateMode(value)),
 });
 
 export default withNavigation(connect(mapStateToProps, mapDispatchToProps)(Settings));

--- a/reducers/connectivity.js
+++ b/reducers/connectivity.js
@@ -1,8 +1,23 @@
-import { SET_CONNECTED } from '../actions/connectivity';
+import { SET_CONNECTED, SET_MODE } from '../actions/connectivity';
 
-export default function reducer(state = false, action) {
+const initial = {
+  connected: false,
+  isOfflineOnly: false,
+};
+
+export default function reducer(state = initial, action) {
   if (action.type === SET_CONNECTED) {
-    return action.connected;
+    return {
+      ...state,
+      connected: action.connected,
+    };
+  }
+
+  if (action.type === SET_MODE) {
+    return {
+      ...state,
+      isOfflineOnly: action.isOfflineOnly,
+    };
   }
 
   return state;

--- a/reducers/index.js
+++ b/reducers/index.js
@@ -15,7 +15,7 @@ import uploads from './uploads';
 // Sorted Alphabetically
 const reducer = combineReducers({
   authentication,
-  connected: connectivity,
+  connectivity,
   i18n,
   locations,
   position,

--- a/screens/locationData.js
+++ b/screens/locationData.js
@@ -125,7 +125,7 @@ LocationData.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-  connected: state.connected,
+  connected: state.connectivity.connected,
   stats: getStats(state),
   failedLocations: getFailedLocations(state),
   uploading: state.uploads.uploading,


### PR DESCRIPTION
Adds the ability to toggle only showing local locations. (Kinda like offline mode in google play music) Used as a workaround to stop the app from becoming to slow if there are too many locations. Setting is remembered between app loads.

Needs translations for the new setting label. (There may also be a better way to word the label)

![screenshot_20180824-123218 1](https://user-images.githubusercontent.com/11445215/44596456-36bda300-a79a-11e8-8667-f1fe5c06ace6.jpg)
