### PR TITLE
Center map when creating new location with "+" button

### DIFF
--- a/screens/overviewMap.js
+++ b/screens/overviewMap.js
@@ -155,7 +155,13 @@ class OverviewMap extends PureComponent {
 
   onAddLocationPress = async () => {
     if (!this.state.tempLocation) {
-      this.createTempPin(this.state);
+      const { location } = await getCurrentPosition(true);
+      if (location) {
+        this.onCenterLocationPress();
+        this.createTempPin(location);
+      } else {
+        this.createTempPin(this.state);
+      }
     }
   }
 

--- a/screens/overviewMap.js
+++ b/screens/overviewMap.js
@@ -156,12 +156,7 @@ class OverviewMap extends PureComponent {
   onAddLocationPress = async () => {
     if (!this.state.tempLocation) {
       const { location } = await getCurrentPosition(true);
-      if (location) {
-        this.onCenterLocationPress();
-        this.createTempPin(location);
-      } else {
-        this.createTempPin(this.state);
-      }
+      this.createTempPin(location || this.state);
     }
   }
 


### PR DESCRIPTION
Ensures the "+" (add new location) button centre on GPS location rather than the centre of the map so that offline users don't have to remember to centre map first.