### PR TITLE
Adjust whichRegion for new format

### DIFF
--- a/__tests__/selectors/whichRegion.js
+++ b/__tests__/selectors/whichRegion.js
@@ -25,7 +25,7 @@ describe('selectors/whichRegion', () => {
 
     expect(selected).toEqual({
       type: 'FeatureCollection',
-      features: ['a', 'b'],
+      features: ['a'],
     });
   });
 

--- a/__tests__/selectors/whichRegion.js
+++ b/__tests__/selectors/whichRegion.js
@@ -23,10 +23,7 @@ describe('selectors/whichRegion', () => {
 
     const selected = selector(state);
 
-    expect(selected).toEqual({
-      type: 'FeatureCollection',
-      features: ['a'],
-    });
+    expect(selected).toEqual('a');
   });
 
   it('memoizes the value', () => {

--- a/selectors/whichRegion.js
+++ b/selectors/whichRegion.js
@@ -5,9 +5,6 @@ const regions = createSelector((state) => state.regions, (data) => Object.values
 
 const geojson = createSelector(regions, (x) => x.map((r) => r.geojson));
 
-export default createSelector(geojson, (features) =>
-  whichPolygon({
-    type: 'FeatureCollection',
-    features,
-  })
+export default createSelector(geojson, (featureCollection) =>
+  whichPolygon(featureCollection[0])
 );

--- a/selectors/whichRegion.js
+++ b/selectors/whichRegion.js
@@ -5,6 +5,14 @@ const regions = createSelector((state) => state.regions, (data) => Object.values
 
 const geojson = createSelector(regions, (x) => x.map((r) => r.geojson));
 
-export default createSelector(geojson, (featureCollection) =>
-  whichPolygon(featureCollection[0])
+export default createSelector(geojson, (featureCollection) => {
+  let regionKey;
+  for (let i = 0; i < featureCollection.length; i += 1) {
+    regionKey = whichPolygon(featureCollection[i]);
+
+    if (regionKey) break;
+  }
+
+  return regionKey;
+}
 );


### PR DESCRIPTION
Adjusts the form of the data we pass `whichRegion` to compensate for the data format changes made in [https://github.com/smaclell/4k/pull/15](https://github.com/smaclell/4k/pull/15)

Might want to check my logic, but after testing it seemed to work well.

Also, I am not exactly sure if the test should change or not