### PR TITLE
Add a simple mechanism for performing migrations in the app

### DIFF
--- a/App.js
+++ b/App.js
@@ -12,7 +12,7 @@ import NavigationService from './utils/NavigationService';
 import Onboarding from './containers/Onboarding';
 import Navigation from './nav';
 import reducer from './reducers';
-import { createDatabases } from './apis/database';
+import createDatabases from './apis/migrations';
 import { initialize } from './apis';
 import { restore } from './actions/authentication';
 import { setup } from './actions/connectivity';

--- a/actions/locations.js
+++ b/actions/locations.js
@@ -82,7 +82,7 @@ export function fetchLocation(locationKey) {
     try {
       const location = await apis.fetchLocation(locationKey, regionKey);
       if (location) {
-        dispatch(receiveLocation({ ...location, uploaded: true }));
+        dispatch(receiveLocation({ version: 0, ...location, uploaded: true }));
       }
     } catch (err) {
       Sentry.captureException(err);

--- a/apis/database.js
+++ b/apis/database.js
@@ -23,16 +23,6 @@ export function executeTransaction(statement, args = null) {
   });
 }
 
-export function createDatabases() {
-  return executeTransaction(
-    'create table if not exists locations (id integer primary key not null, key text, coordinateKey text, createdAt text, resources text, status text, uploaded int)'
-  );
-}
-
-export function clearDatabase() {
-  return executeTransaction('drop table locations');
-}
-
 export function updateUploadStatus(key, isUploaded) {
   return executeTransaction('update locations set uploaded = ? where key = ?', [isUploaded, key]);
 }

--- a/apis/migrations.js
+++ b/apis/migrations.js
@@ -1,0 +1,26 @@
+/* eslint no-await-in-loop: 0 */
+import Sentry from 'sentry-expo';
+import { executeTransaction } from './database';
+
+const migrations = [
+  () =>
+    executeTransaction(
+      'CREATE TABLE IF NOT EXISTS locations (id integer PRIMARY KEY NOT NULL, key text, coordinateKey text, createdAt text, resources text, status text, uploaded int)'
+    ),
+  () => executeTransaction('ALTER TABLE locations ADD COLUMN version integer NOT NULL DEFAULT 0'),
+];
+
+export default async function createDatabases() {
+  const result = await executeTransaction('PRAGMA user_version');
+  const version = result.rows.item(0).user_version || -1;
+
+  for (let i = version + 1; i < migrations.length; i += 1) {
+    try {
+      await migrations[i]();
+      await executeTransaction(`PRAGMA user_version = ${i}`);
+    } catch (err) {
+      Sentry.captureException(err, { extra: { migration: i } });
+      throw err;
+    }
+  }
+}

--- a/utils/database.js
+++ b/utils/database.js
@@ -28,7 +28,7 @@ export async function getCoordinates(key) {
 }
 
 export async function convertToLocation(location) {
-  const { key, resources, status, uploaded } = location;
+  const { key, resources, status, uploaded, version } = location;
   const created = moment(location.createdAt).valueOf();
   const { longitude, latitude } = await getCoordinates(key);
   return {
@@ -39,6 +39,7 @@ export async function convertToLocation(location) {
     longitude,
     latitude,
     uploaded: uploaded === LOCATION_UPLOADED.true,
+    version,
   };
 }
 


### PR DESCRIPTION
A nice little script to help out with migrations. It turns out the SQLite can store a bit of data to help with versioning the database: https://stackoverflow.com/questions/989558/best-practices-for-in-app-database-migration-for-sqlite

My Testing:

* Saving a location
* Wiping out the database, add some data and then trying to see what it would publish (this worked flawlessly, the uploaded data was correctly versioned)